### PR TITLE
fix: remove wrong languages on typescriptreact and javascriptreact

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,17 +48,12 @@
             {
                 "id": "javascriptreact",
                 "extensions": [
-                    ".js",
-                    ".jsx",
-                    ".ts",
-                    ".tsx"
+                    ".jsx"
                 ]
             },
             {
                 "id": "typescript",
                 "extensions": [
-                    ".js",
-                    ".jsx",
                     ".ts",
                     ".tsx"
                 ]
@@ -66,9 +61,6 @@
             {
                 "id": "typescriptreact",
                 "extensions": [
-                    ".js",
-                    ".jsx",
-                    ".ts",
                     ".tsx"
                 ]
             }


### PR DESCRIPTION
Hi, I removed the languages as the `*react` langues override the not jsx files.

I discovered it as the icon with the Material Icons, the `ts` files have the same icons as the `tsx` files.